### PR TITLE
"Final" fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -325,7 +325,8 @@ utils/config.ml: utils/config.mlp config/Makefile
 	    -e 's|%%LIBUNWIND_AVAILABLE%%|$(LIBUNWIND_AVAILABLE)|' \
 	    -e 's|%%LIBUNWIND_LINK_FLAGS%%|$(LIBUNWIND_LINK_FLAGS)|' \
 	    -e 's|%%MKDLL%%|$(subst \,\\,$(MKDLL))|' \
-	    -e 's|%%MKEXE%%|$(subst \,\\,$(MKEXE))|' \
+	    -e 's|%%MKEXE%%|$(subst ",\\",$(subst \,\\,$(MKEXE)))|' \
+	    -e 's|%%FLEXLINK_LDFLAGS%%|$(subst ",\\",$(subst \,\\,$(if $(LDFLAGS), -link "$(LDFLAGS)")))|' \
 	    -e 's|%%MKMAINDLL%%|$(subst \,\\,$(MKMAINDLL))|' \
 	    -e 's|%%MODEL%%|$(MODEL)|' \
 	    -e 's|%%NATIVECCLIBS%%|$(NATIVECCLIBS)|' \

--- a/Makefile
+++ b/Makefile
@@ -69,12 +69,6 @@ else
 OCAML_NATDYNLINKOPTS = -ccopt "$(NATDYNLINKOPTS)"
 endif
 
-ifeq "$(strip $(LDFLAGS))" ""
-OCAML_LDFLAGS=
-else
-OCAML_LDFLAGS = -ccopt "$(LDFLAGS)"
-endif
-
 YACCFLAGS=-v --strict
 CAMLLEX=$(CAMLRUN) boot/ocamllex
 CAMLDEP=$(CAMLRUN) tools/ocamldep
@@ -868,8 +862,7 @@ partialclean::
 
 ocamlc.opt: compilerlibs/ocamlcommon.cmxa compilerlibs/ocamlbytecomp.cmxa \
             $(BYTESTART:.cmo=.cmx)
-	$(CAMLOPT) $(LINKFLAGS) $(OCAML_LDFLAGS) -o $@ \
-	  $^ -cclib "$(BYTECCLIBS)"
+	$(CAMLOPT) $(LINKFLAGS) -o $@ $^ -cclib "$(BYTECCLIBS)"
 
 partialclean::
 	rm -f ocamlc.opt

--- a/byterun/main.c
+++ b/byterun/main.c
@@ -31,19 +31,16 @@ CAMLextern void caml_main (charnat **);
 #ifdef _WIN32
 CAMLextern void caml_expand_command_line (int *, wchar_t ***);
 
-int main(void)
-{
-  int argc;
-  wchar_t **argv;
-
-  argv = CommandLineToArgvW(GetCommandLine(), &argc);
-
-  /* Expand wildcards and diversions in command line */
-  caml_expand_command_line(&argc, &argv);
+int wmain(int argc, wchar_t **argv)
 #else
 int main(int argc, char **argv)
-{
 #endif
+{
+#ifdef _WIN32
+  /* Expand wildcards and diversions in command line */
+  caml_expand_command_line(&argc, &argv);
+#endif
+
   caml_main(argv);
   caml_sys_exit(Val_int(0));
   return 0; /* not reached */

--- a/config/Makefile.mingw
+++ b/config/Makefile.mingw
@@ -144,12 +144,15 @@ endif
 #   $(FLEXLINK_CMD) $(FLEXLINK_FLAGS) [-exe|-maindll]
 # or OCAML_FLEXLINK overriding will not work (see utils/config.mlp)
 MKDLL=$(FLEXLINK)
-MKEXE=$(FLEXLINK) -exe $(if $(LDFLAGS),-link "$(LDFLAGS)")
+MKEXE=$(MKEXE_ANSI) $(if $(LDFLAGS),-link "$(LDFLAGS)")
 MKEXEDEBUGFLAG=-g
 MKMAINDLL=$(FLEXLINK) -maindll
 
 ### Native command to build ocamlrun.exe without flexlink
 MKEXE_BOOT=$(CC) $(CFLAGS) $(LDFLAGS) $(OUTPUTEXE)$(1) $(2)
+
+### Native command to build an ANSI executable
+MKEXE_ANSI=$(FLEXLINK) -exe
 
 ### How to build a static library
 MKLIB=rm -f $(1); $(TOOLPREF)ar rc $(1) $(2); $(RANLIB) $(1)

--- a/config/Makefile.mingw
+++ b/config/Makefile.mingw
@@ -118,7 +118,7 @@ OCAMLC_CFLAGS = -O -mms-bitfields
 
 BYTECCDBGCOMPOPTS=-g
 
-LDFLAGS=
+LDFLAGS=-municode
 
 ### Libraries needed
 BYTECCLIBS=-lws2_32 -lshell32
@@ -144,12 +144,12 @@ endif
 #   $(FLEXLINK_CMD) $(FLEXLINK_FLAGS) [-exe|-maindll]
 # or OCAML_FLEXLINK overriding will not work (see utils/config.mlp)
 MKDLL=$(FLEXLINK)
-MKEXE=$(FLEXLINK) -exe
+MKEXE=$(FLEXLINK) -exe $(if $(LDFLAGS),-link "$(LDFLAGS)")
 MKEXEDEBUGFLAG=-g
 MKMAINDLL=$(FLEXLINK) -maindll
 
 ### Native command to build ocamlrun.exe without flexlink
-MKEXE_BOOT=$(CC) $(CFLAGS) $(OUTPUTEXE)$(1) $(2)
+MKEXE_BOOT=$(CC) $(CFLAGS) $(LDFLAGS) $(OUTPUTEXE)$(1) $(2)
 
 ### How to build a static library
 MKLIB=rm -f $(1); $(TOOLPREF)ar rc $(1) $(2); $(RANLIB) $(1)

--- a/config/Makefile.mingw64
+++ b/config/Makefile.mingw64
@@ -144,12 +144,15 @@ endif
 #   $(FLEXLINK_CMD) $(FLEXLINK_FLAGS) [-exe|-maindll]
 # or OCAML_FLEXLINK overriding will not work (see utils/config.mlp)
 MKDLL=$(FLEXLINK)
-MKEXE=$(FLEXLINK) -exe $(if $(LDFLAGS),-link "$(LDFLAGS)")
+MKEXE=$(MKEXE_ANSI) $(if $(LDFLAGS),-link "$(LDFLAGS)")
 MKEXEDEBUGFLAG=-g
 MKMAINDLL=$(FLEXLINK) -maindll
 
 ### Native command to build ocamlrun.exe without flexlink
 MKEXE_BOOT=$(CC) $(CFLAGS) $(LDFLAGS) $(OUTPUTEXE)$(1) $(2)
+
+### Native command to build an ANSI executable
+MKEXE_ANSI=$(FLEXLINK) -exe
 
 ### How to build a static library
 MKLIB=rm -f $(1); $(TOOLPREF)ar rc $(1) $(2); $(RANLIB) $(1)

--- a/config/Makefile.mingw64
+++ b/config/Makefile.mingw64
@@ -118,7 +118,7 @@ OCAMLC_CFLAGS = -O -mms-bitfields
 
 BYTECCDBGCOMPOPTS=-g
 
-LDFLAGS=
+LDFLAGS=-municode
 
 ### Libraries needed
 BYTECCLIBS=-lws2_32 -lshell32
@@ -144,12 +144,12 @@ endif
 #   $(FLEXLINK_CMD) $(FLEXLINK_FLAGS) [-exe|-maindll]
 # or OCAML_FLEXLINK overriding will not work (see utils/config.mlp)
 MKDLL=$(FLEXLINK)
-MKEXE=$(FLEXLINK) -exe
+MKEXE=$(FLEXLINK) -exe $(if $(LDFLAGS),-link "$(LDFLAGS)")
 MKEXEDEBUGFLAG=-g
 MKMAINDLL=$(FLEXLINK) -maindll
 
 ### Native command to build ocamlrun.exe without flexlink
-MKEXE_BOOT=$(CC) $(CFLAGS) $(OUTPUTEXE)$(1) $(2)
+MKEXE_BOOT=$(CC) $(CFLAGS) $(LDFLAGS) $(OUTPUTEXE)$(1) $(2)
 
 ### How to build a static library
 MKLIB=rm -f $(1); $(TOOLPREF)ar rc $(1) $(2); $(RANLIB) $(1)

--- a/config/Makefile.msvc
+++ b/config/Makefile.msvc
@@ -135,7 +135,7 @@ endif
 #   $(FLEXLINK_CMD) $(FLEXLINK_FLAGS) [-exe|-maindll]
 # or OCAML_FLEXLINK overriding will not work (see utils/config.mlp)
 MKDLL=$(FLEXLINK)
-MKEXE=$(FLEXLINK) -exe $(if $(LDFLAGS),-link "$(LDFLAGS)")
+MKEXE=$(MKEXE_ANSI) $(if $(LDFLAGS),-link "$(LDFLAGS)")
 MKEXEDEBUGFLAG=
 MKMAINDLL=$(FLEXLINK) -maindll
 
@@ -145,6 +145,9 @@ MERGEMANIFESTEXE=test ! -f $(1).manifest \
 	            && rm -f $(1).manifest
 MKEXE_BOOT=$(CC) $(CFLAGS) $(OUTPUTEXE)$(1) $(2) /link /subsystem:console $(LDFLAGS) \
 	   && ($(MERGEMANIFESTEXE))
+
+### Native command to build an ANSI executable
+MKEXE_ANSI=$(FLEXLINK) -exe
 
 ### How to build a static library
 MKLIB=link -lib -nologo -out:$(1) $(2)

--- a/config/Makefile.msvc
+++ b/config/Makefile.msvc
@@ -109,7 +109,7 @@ OCAMLC_CFLAGS = -nologo -O2 -Gy- -MD
 OCAMLC_CPPFLAGS = -D_CRT_SECURE_NO_DEPRECATE
 BYTECCDBGCOMPOPTS=-Zi
 
-LDFLAGS=
+LDFLAGS=/ENTRY:wmainCRTStartup
 
 ### Libraries needed
 BYTECCLIBS=advapi32.lib ws2_32.lib shell32.lib
@@ -135,7 +135,7 @@ endif
 #   $(FLEXLINK_CMD) $(FLEXLINK_FLAGS) [-exe|-maindll]
 # or OCAML_FLEXLINK overriding will not work (see utils/config.mlp)
 MKDLL=$(FLEXLINK)
-MKEXE=$(FLEXLINK) -exe
+MKEXE=$(FLEXLINK) -exe $(if $(LDFLAGS),-link "$(LDFLAGS)")
 MKEXEDEBUGFLAG=
 MKMAINDLL=$(FLEXLINK) -maindll
 
@@ -143,7 +143,7 @@ MKMAINDLL=$(FLEXLINK) -maindll
 MERGEMANIFESTEXE=test ! -f $(1).manifest \
 	         || mt -nologo -outputresource:$(1) -manifest $(1).manifest \
 	            && rm -f $(1).manifest
-MKEXE_BOOT=$(CC) $(CFLAGS) $(OUTPUTEXE)$(1) $(2) /link /subsystem:console \
+MKEXE_BOOT=$(CC) $(CFLAGS) $(OUTPUTEXE)$(1) $(2) /link /subsystem:console $(LDFLAGS) \
 	   && ($(MERGEMANIFESTEXE))
 
 ### How to build a static library

--- a/config/Makefile.msvc64
+++ b/config/Makefile.msvc64
@@ -109,7 +109,7 @@ OCAMLC_CPPFLAGS = -D_CRT_SECURE_NO_DEPRECATE
 
 BYTECCDBGCOMPOPTS=-Zi
 
-LDFLAGS=
+LDFLAGS=/ENTRY:wmainCRTStartup
 
 ### Libraries needed
 #EXTRALIBS=bufferoverflowu.lib  # for the old PSDK compiler only
@@ -137,7 +137,7 @@ endif
 #   $(FLEXLINK_CMD) $(FLEXLINK_FLAGS) [-exe|-maindll]
 # or OCAML_FLEXLINK overriding will not work (see utils/config.mlp)
 MKDLL=$(FLEXLINK)
-MKEXE=$(FLEXLINK) -exe
+MKEXE=$(FLEXLINK) -exe $(if $(LDFLAGS),-link "$(LDFLAGS)")
 MKEXEDEBUGFLAG=
 MKMAINDLL=$(FLEXLINK) -maindll
 
@@ -145,7 +145,7 @@ MKMAINDLL=$(FLEXLINK) -maindll
 MERGEMANIFESTEXE=test ! -f $(1).manifest \
 	         || mt -nologo -outputresource:$(1) -manifest $(1).manifest \
 	            && rm -f $(1).manifest
-MKEXE_BOOT=$(CC) $(CFLAGS) $(OUTPUTEXE)$(1) $(2) /link /subsystem:console \
+MKEXE_BOOT=$(CC) $(CFLAGS) $(OUTPUTEXE)$(1) $(2) /link /subsystem:console $(LDFLAGS) \
            && ($(MERGEMANIFESTEXE))
 
 ### How to build a static library

--- a/config/Makefile.msvc64
+++ b/config/Makefile.msvc64
@@ -137,7 +137,7 @@ endif
 #   $(FLEXLINK_CMD) $(FLEXLINK_FLAGS) [-exe|-maindll]
 # or OCAML_FLEXLINK overriding will not work (see utils/config.mlp)
 MKDLL=$(FLEXLINK)
-MKEXE=$(FLEXLINK) -exe $(if $(LDFLAGS),-link "$(LDFLAGS)")
+MKEXE=$(MKEXE_ANSI) $(if $(LDFLAGS),-link "$(LDFLAGS)")
 MKEXEDEBUGFLAG=
 MKMAINDLL=$(FLEXLINK) -maindll
 
@@ -147,6 +147,9 @@ MERGEMANIFESTEXE=test ! -f $(1).manifest \
 	            && rm -f $(1).manifest
 MKEXE_BOOT=$(CC) $(CFLAGS) $(OUTPUTEXE)$(1) $(2) /link /subsystem:console $(LDFLAGS) \
            && ($(MERGEMANIFESTEXE))
+
+### Native command to build an ANSI executable
+MKEXE_ANSI=$(FLEXLINK) -exe
 
 ### How to build a static library
 MKLIB=link -lib -nologo -machine:AMD64 /out:$(1) $(2)

--- a/otherlibs/unix/execvp.c
+++ b/otherlibs/unix/execvp.c
@@ -25,7 +25,7 @@ CAMLprim value unix_execvp(value path, value args)
   charnat * wpath;
   caml_unix_check_path(path, "execvp");
   argv = cstringvect(args, "execvp");
-  wpath = caml_stat_strdup_to_utf16((char *)String_val(path));
+  wpath = caml_stat_strdup_to_utf16(String_val(path));
   (void) _texecvp(wpath, EXECV_CAST argv);
   caml_stat_free(wpath);
   cstringvect_free(argv);
@@ -40,13 +40,13 @@ CAMLprim value unix_execvpe(value path, value args, value env)
   charnat ** argv;
   charnat ** envp;
   caml_unix_check_path(path, "execvpe");
-  wpath = caml_stat_strdup_to_utf16((char *)String_val(path));
+  wpath = caml_stat_strdup_to_utf16(String_val(path));
   exefile = caml_search_exe_in_path(wpath);
-  caml_stat_free((charnat *)wpath);
+  caml_stat_free(wpath);
   argv = cstringvect(args, "execvpe");
   envp = cstringvect(env, "execvpe");
   (void) _texecve(exefile, EXECV_CAST argv, EXECV_CAST envp);
-  caml_stat_free((charnat *)exefile);
+  caml_stat_free(exefile);
   cstringvect_free(argv);
   cstringvect_free(envp);
   uerror("execvpe", path);

--- a/otherlibs/unix/execvp.c
+++ b/otherlibs/unix/execvp.c
@@ -26,7 +26,7 @@ CAMLprim value unix_execvp(value path, value args)
   caml_unix_check_path(path, "execvp");
   argv = cstringvect(args, "execvp");
   wpath = caml_stat_strdup_to_utf16(String_val(path));
-  (void) _texecvp(wpath, EXECV_CAST argv);
+  (void) _texecvp((const charnat *)wpath, EXECV_CAST argv);
   caml_stat_free(wpath);
   cstringvect_free(argv);
   uerror("execvp", path);
@@ -36,7 +36,7 @@ CAMLprim value unix_execvp(value path, value args)
 
 CAMLprim value unix_execvpe(value path, value args, value env)
 {
-  const charnat * exefile, * wpath;
+  charnat * exefile, * wpath;
   charnat ** argv;
   charnat ** envp;
   caml_unix_check_path(path, "execvpe");
@@ -45,7 +45,7 @@ CAMLprim value unix_execvpe(value path, value args, value env)
   caml_stat_free(wpath);
   argv = cstringvect(args, "execvpe");
   envp = cstringvect(env, "execvpe");
-  (void) _texecve(exefile, EXECV_CAST argv, EXECV_CAST envp);
+  (void) _texecve((const charnat *)exefile, EXECV_CAST argv, EXECV_CAST envp);
   caml_stat_free(exefile);
   cstringvect_free(argv);
   cstringvect_free(envp);

--- a/stdlib/headernt.c
+++ b/stdlib/headernt.c
@@ -23,7 +23,6 @@
 #include "caml/exec.h"
 
 #ifndef __MINGW32__
-#pragma comment(linker , "/entry:headerentry")
 #pragma comment(linker , "/subsystem:console")
 #pragma comment(lib , "kernel32")
 #ifdef _UCRT
@@ -146,11 +145,7 @@ static __inline void __declspec(noreturn) run_runtime(wchar_t * runtime,
 #endif
 }
 
-#ifdef __MINGW32__
-int main()
-#else
-void __declspec(noreturn) __cdecl headerentry()
-#endif
+int wmain(void)
 {
   wchar_t truename[MAX_PATH];
   wchar_t * cmdline = GetCommandLine();

--- a/testsuite/tests/embedded/Makefile
+++ b/testsuite/tests/embedded/Makefile
@@ -25,7 +25,7 @@ compile:
 	@$(OCAMLC) -ccopt -I -ccopt $(CTOPDIR)/byterun cmstub.c
 	@$(OCAMLC) -ccopt -I -ccopt $(CTOPDIR)/byterun cmmain.c
 	@$(OCAMLC) -c cmcaml.ml
-	@$(OCAMLC) -custom $(if $(filter mingw,$(TOOLCHAIN)),-ccopt -link -ccopt -municode,) -o program cmstub.$(O) cmcaml.cmo cmmain.$(O)
+	@$(OCAMLC) -custom -o program cmstub.$(O) cmcaml.cmo cmmain.$(O)
 
 .PHONY: run
 run:

--- a/testsuite/tests/win-unicode/Makefile
+++ b/testsuite/tests/win-unicode/Makefile
@@ -23,4 +23,4 @@ include $(BASEDIR)/makefiles/Makefile.several
 include $(BASEDIR)/makefiles/Makefile.common
 
 %.exe: %.c
-	@$(CC) $(CFLAGS) $(CPPFLAGS) $(if $(filter msvc,$(CCOMPTYPE)),/Fe$*.exe,-o$*.exe) $*.c
+	@$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $(if $(filter msvc,$(CCOMPTYPE)),/Fe$*.exe,-o$*.exe) $*.c

--- a/testsuite/tests/win-unicode/Makefile
+++ b/testsuite/tests/win-unicode/Makefile
@@ -23,4 +23,4 @@ include $(BASEDIR)/makefiles/Makefile.several
 include $(BASEDIR)/makefiles/Makefile.common
 
 %.exe: %.c
-	@$(CC) $(CFLAGS) $(CPPFLAGS) $(if $(filter msvc,$(CCOMPTYPE)),/Fe$*.exe,-municode -o$*.exe) $*.c
+	@$(CC) $(CFLAGS) $(CPPFLAGS) $(if $(filter msvc,$(CCOMPTYPE)),/Fe$*.exe,-o$*.exe) $*.c

--- a/testsuite/tests/win-unicode/Makefile
+++ b/testsuite/tests/win-unicode/Makefile
@@ -22,5 +22,7 @@ symlink_tests.precheck:
 include $(BASEDIR)/makefiles/Makefile.several
 include $(BASEDIR)/makefiles/Makefile.common
 
+GENERATED_SOURCES=symlink_tests.precheck
+
 %.exe: %.c
 	@$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $(if $(filter msvc,$(CCOMPTYPE)),/Fe$*.exe,-o$*.exe) $*.c

--- a/testsuite/tests/win-unicode/exec_tests.ml
+++ b/testsuite/tests/win-unicode/exec_tests.ml
@@ -1,0 +1,63 @@
+let values =
+  [
+    "\xD0\xB2\xD0\xB5\xD1\x80\xD0\xB1\xD0\xBB\xD1\x8E\xD0\xB4\xD1\x8B"; (* "верблюды" *)
+    "\xE9\xAA\x86\xE9\xA9\xBC"; (* "骆驼" *)
+    "\215\167\215\162\215\158\215\156"; (* "קעמל" *)
+    "\216\167\217\136\217\134\217\185"; (* "اونٹ" *)
+  ]
+
+let env0 =
+  List.sort compare (List.mapi (fun i v -> Printf.sprintf "OCAML_UTF8_VAR%d=%s" i v) values)
+
+let split sep s =
+  match String.index s sep with
+  | i ->
+      String.sub s 0 i, String.sub s (i + 1) (String.length s - i - 1)
+  | exception Not_found ->
+      s, ""
+
+let test_environment () =
+  print_endline "test_environment";
+  let vars = List.map (fun s -> fst (split '=' s)) env0 in
+  let f s = List.mem (fst (split '=' s)) vars in
+  let env = List.filter f (Array.to_list (Unix.environment ())) in
+  assert (List.length env0 = List.length env);
+  List.iter2 (fun s1 s2 -> assert (s1 = s2)) env0 env
+
+let test0 () =
+  print_endline "test0";
+  Unix.execve Sys.executable_name [|Sys.executable_name; "1"|] (Array.of_list env0)
+
+let test_argv () =
+  print_endline "test_argv";
+  let argv = match Array.to_list Sys.argv with _ :: _ :: argv -> argv | _ -> assert false in
+  List.iter2 (fun s1 s2 -> assert (s1 = s2)) argv values
+
+let test1 () =
+  print_endline "test1";
+  Unix.execv Sys.executable_name (Array.of_list (Sys.executable_name :: "2" :: values))
+
+let restart = function
+  | 0 -> test0 ()
+  | 1 -> test_environment (); test1 ()
+  | 2 -> test_argv ()
+  | _ -> assert false
+
+let main () =
+  match Array.length Sys.argv with
+  | 1 ->
+      let pid = Unix.create_process Sys.executable_name [|Sys.executable_name; "0"|] Unix.stdin Unix.stdout Unix.stderr in
+      begin match Unix.waitpid [] pid with
+      | _, Unix.WEXITED 0 -> ()
+      | _, (Unix.WEXITED _ | Unix.WSIGNALED _ | Unix.WSTOPPED _) -> failwith "Child process error"
+      end
+  | _ ->
+      restart (int_of_string Sys.argv.(1))
+
+let () =
+  match main () with
+  | () ->
+      Printf.printf "OK\n%!"
+  | exception e ->
+      Printf.printf "BAD: %s\n%!" (Printexc.to_string e);
+      exit 1

--- a/testsuite/tests/win-unicode/mltest.ml
+++ b/testsuite/tests/win-unicode/mltest.ml
@@ -79,8 +79,8 @@ let file_kind = function
   | Unix.S_CHR -> "S_CHR"
   | Unix.S_BLK -> "S_BLK"
   | Unix.S_LNK -> "S_LNK"
-  | Unix.S_FIFO	-> "S_FIFO"
-  | Unix.S_SOCK	-> "S_SOCK"
+  | Unix.S_FIFO -> "S_FIFO"
+  | Unix.S_SOCK -> "S_SOCK"
 
 let wrap s f quote_in x quote_out =
   Printf.printf "%s %s ... " s (quote_in x);

--- a/utils/config.mlp
+++ b/utils/config.mlp
@@ -53,7 +53,7 @@ let mkdll, mkexe, mkmaindll =
           if c = '/' then '\\' else c in
         (String.init (String.length flexlink) f) ^ " %%FLEXLINK_FLAGS%%" in
       flexlink,
-      flexlink ^ " -exe",
+      flexlink ^ " -exe%%FLEXLINK_LDFLAGS%%",
       flexlink ^ " -maindll"
     with Not_found ->
       "%%MKDLL%%", "%%MKEXE%%", "%%MKMAINDLL%%"

--- a/yacc/Makefile
+++ b/yacc/Makefile
@@ -23,8 +23,12 @@ OBJS= closure.$(O) error.$(O) lalr.$(O) lr0.$(O) main.$(O) \
 
 all: ocamlyacc$(EXE)
 
+ifeq ($(TOOLCHAIN),cc)
+MKEXE_ANSI=$(MKEXE)
+endif
+
 ocamlyacc$(EXE): $(OBJS)
-	$(MKEXE) -o ocamlyacc$(EXE) $(OBJS) $(EXTRALIBS)
+	$(MKEXE_ANSI) -o ocamlyacc$(EXE) $(OBJS) $(EXTRALIBS)
 
 version.h : ../VERSION
 	echo "#define OCAML_VERSION \"`sed -e 1q $^ | tr -d '\r'`\"" > $@


### PR DESCRIPTION
The main change here is to ensure that all applications are built as "true" Windows Unicode applications (so really entering through wmain on Windows). This means that `-municode` or `/entry:wmainCRTStartup` is communicated by the build system. This is a good change for principle of least surprise - if libcamlrun defines a main symbol and you then link your application with wmain but forget the -municode then you get an unexpected application since it calls libcamlrun's main instead of your wmain. With the library built this way, you get a link error as you'd expect.

I've put your exec tests back in - let's see how they go... we can always disable, rather than delete, if they prove problematic.
