### PR TITLE
Add support for top-level floatarray printing

### DIFF
--- a/testsuite/tests/typing-extensions/floatarray.ml
+++ b/testsuite/tests/typing-extensions/floatarray.ml
@@ -11,13 +11,13 @@ val x : float array = [|1.; 2.|]
 let x : floatarray = [|1.; 2.|]
 ;;
 [%%expect {|
-val x : floatarray = <abstr>
+val x : floatarray = [|1.; 2.|]
 |}]
 
 let x = ([|1.; 2.|] : floatarray)
 ;;
 [%%expect {|
-val x : floatarray = <abstr>
+val x : floatarray = [|1.; 2.|]
 |}]
 
 let f (a : floatarray) = match a with [|x|] -> x | _ -> assert false
@@ -51,7 +51,7 @@ let x : t = [||]
 [%%expect {|
 type s = floatarray
 type t = s
-val x : t = <abstr>
+val x : t = [||]
 |}]
 
 let f a =

--- a/toplevel/genprintval.ml
+++ b/toplevel/genprintval.ml
@@ -334,6 +334,10 @@ module Make(O : OBJ)(EVP : EVALPATH with type valu = O.t) = struct
                 let s = Bytes.to_string (O.obj obj : bytes) in
                 Oval_string (s, !printer_steps, Ostr_bytes)
 
+              | Tconstr(path, [], _)
+                  when Path.same path Predef.path_floatarray ->
+                Oval_floatarray (O.obj obj : floatarray)
+
               | Tconstr (path, [ty_arg], _)
                 when Path.same path Predef.path_lazy_t ->
                 let obj_tag = O.tag obj in

--- a/typing/oprint.ml
+++ b/typing/oprint.ml
@@ -208,6 +208,10 @@ let print_out_value ppf tree =
     | Oval_printer f -> f ppf
     | Oval_tuple tree_list ->
         fprintf ppf "@[<1>(%a)@]" (print_tree_list print_tree_1 ",") tree_list
+    | Oval_floatarray arr ->
+       fprintf ppf "@[<2>[|%a|]@]"
+         (pp_print_seq ~pp_sep:semicolon pp_print_float)
+         (Float.Array.to_seq arr)
     | tree -> fprintf ppf "@[<1>(%a)@]" (cautious print_tree_1) tree
   and print_fields first ppf =
     function

--- a/typing/outcometree.mli
+++ b/typing/outcometree.mli
@@ -56,6 +56,7 @@ type out_value =
   | Oval_tuple of out_value list
   | Oval_variant of string * out_value option
   | Oval_lazy of out_value
+  | Oval_floatarray of floatarray
 
 type out_type_param = {
     ot_non_gen: bool;

--- a/utils/format_doc.ml
+++ b/utils/format_doc.ml
@@ -456,6 +456,7 @@ let pp_print_either  ~left ~right ppf e =
   ppf := Doc.either ~left:(doc_printer left) ~right:(doc_printer right) e !ppf
 
 let comma ppf () = fprintf ppf ",@ "
+let semicolon ppf () = fprintf ppf ";@ "
 
 let pp_two_columns ?(sep = "|") ?max_lines ppf (lines: (string * string) list) =
   let left_column_size =

--- a/utils/format_doc.mli
+++ b/utils/format_doc.mli
@@ -267,6 +267,7 @@ val pp_print_newline: unit printer
 (** {2 Separators }*)
 
 val comma: unit printer
+val semicolon: unit printer
 
 (** {2 Compiler output} *)
 


### PR DESCRIPTION
Built atop https://github.com/ocaml/ocaml/pull/13365. so 72c69a90fcb108fe3c1d834eec5f2672602b91ed should disappear after a rebase on `trunk` when that PR is merged.